### PR TITLE
[#28] Clarify login page copy for magic link auth flow

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -46,9 +46,10 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <CardTitle className="text-2xl">Log in</CardTitle>
+          <CardTitle className="text-2xl">Welcome to Jiujitsology</CardTitle>
           <CardDescription>
-            Enter your email and we&apos;ll send you a magic link.
+            Enter your email to sign in or create an account. We&apos;ll
+            send you a magic link — no password needed.
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Ticket
Closes #28
Parent Epic: #1 — User Authentication

## Summary
Updates the login page heading and description to make it clear the form works for both new and existing users. Changes "Log in" to "Welcome to Jiujitsology" and adds copy explaining magic link auth works for signup too.

## Changes Made
- `app/(auth)/login/page.tsx` — Updated `CardTitle` and `CardDescription` copy

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

## Checklist
- [x] Copy-only change, no logic modifications
- [x] No hardcoded URLs