### PR TITLE
[#35] Implement video deletion with full cascade cleanup

### DIFF
--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -48,7 +48,7 @@ export default function VideosPage() {
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading videos...</p>
       ) : (
-        <VideoList videos={videos} />
+        <VideoList videos={videos} onDelete={fetchVideos} />
       )}
     </div>
   );

--- a/app/api/videos/[id]/route.ts
+++ b/app/api/videos/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Fetch video to get storage_path (RLS ensures only owner's video is returned)
+  const { data: video, error: fetchError } = await supabase
+    .from("videos")
+    .select("id, storage_path")
+    .eq("id", id)
+    .single();
+
+  if (fetchError || !video) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Delete the video record (cascades to transcriptions, chunks, nodes, edges)
+  const { error: deleteError } = await supabase
+    .from("videos")
+    .delete()
+    .eq("id", id);
+
+  if (deleteError) {
+    return NextResponse.json(
+      { error: `Failed to delete: ${deleteError.message}` },
+      { status: 500 }
+    );
+  }
+
+  // Delete the file from Supabase Storage
+  const { error: storageError } = await supabase.storage
+    .from("videos")
+    .remove([video.storage_path]);
+
+  if (storageError) {
+    // Log but don't fail — DB record is already gone
+    console.error(
+      `Failed to delete storage file ${video.storage_path}:`,
+      storageError.message
+    );
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/components/videos/video-list.tsx
+++ b/components/videos/video-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Card,
   CardContent,
@@ -7,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 interface Video {
   id: string;
@@ -20,6 +22,7 @@ interface Video {
 
 interface VideoListProps {
   videos: Video[];
+  onDelete: () => void;
 }
 
 const statusLabels: Record<string, { label: string; className: string }> = {
@@ -31,7 +34,31 @@ const statusLabels: Record<string, { label: string; className: string }> = {
   error: { label: "Error", className: "text-destructive" },
 };
 
-export function VideoList({ videos }: VideoListProps) {
+export function VideoList({ videos, onDelete }: VideoListProps) {
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  async function handleDelete(video: Video) {
+    const confirmed = window.confirm(
+      `Delete '${video.title}'? This will remove the video and all associated data (transcriptions, knowledge graph entries). This cannot be undone.`
+    );
+
+    if (!confirmed) return;
+
+    setDeleting(video.id);
+
+    const response = await fetch(`/api/videos/${video.id}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const data = await response.json();
+      alert(data.error || "Failed to delete video.");
+    }
+
+    setDeleting(null);
+    onDelete();
+  }
+
   if (videos.length === 0) {
     return (
       <p className="text-muted-foreground text-sm">
@@ -54,9 +81,20 @@ export function VideoList({ videos }: VideoListProps) {
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-base">{video.title}</CardTitle>
-                <span className={`text-xs font-medium ${status.className}`}>
-                  {status.label}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className={`text-xs font-medium ${status.className}`}>
+                    {status.label}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-destructive h-7 px-2"
+                    onClick={() => handleDelete(video)}
+                    disabled={deleting === video.id}
+                  >
+                    {deleting === video.id ? "Deleting..." : "Delete"}
+                  </Button>
+                </div>
               </div>
               <CardDescription>{video.filename}</CardDescription>
             </CardHeader>

--- a/supabase/migrations/003_cascade_video_delete.sql
+++ b/supabase/migrations/003_cascade_video_delete.sql
@@ -1,0 +1,12 @@
+-- Add ON DELETE CASCADE to nodes.source_video_id and edges.source_video_id
+-- so deleting a video automatically cleans up associated graph data.
+
+ALTER TABLE nodes
+  DROP CONSTRAINT IF EXISTS nodes_source_video_id_fkey,
+  ADD CONSTRAINT nodes_source_video_id_fkey
+    FOREIGN KEY (source_video_id) REFERENCES videos(id) ON DELETE CASCADE;
+
+ALTER TABLE edges
+  DROP CONSTRAINT IF EXISTS edges_source_video_id_fkey,
+  ADD CONSTRAINT edges_source_video_id_fkey
+    FOREIGN KEY (source_video_id) REFERENCES videos(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Ticket
Closes #35
Parent Epic: #2 — Video Ingestion Pipeline

## Summary
Implements video deletion that cleans up all associated data: the database record (cascading to transcriptions, chunks, nodes, edges via source_video_id), and the file in Supabase Storage. Adds a delete button with confirmation dialog to the video list.

## Changes Made
- `supabase/migrations/003_cascade_video_delete.sql` — Adds ON DELETE CASCADE to `nodes.source_video_id` and `edges.source_video_id` foreign keys
- `app/api/videos/[id]/route.ts` — DELETE handler: auth check, fetch video for storage_path, delete DB record (cascades), delete storage file, return 204
- `components/videos/video-list.tsx` — Added delete button per video card with `window.confirm()` dialog and loading state
- `app/(dashboard)/videos/page.tsx` — Pass `onDelete={fetchVideos}` to VideoList

## Testing
### Automated Tests
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

### Manual Testing
- Upload a video, click Delete, confirm → video disappears from list
- Verify file is removed from Supabase Storage
- Verify unauthenticated DELETE returns 401
- Verify DELETE on non-existent ID returns 404

## Checklist
- [x] All tests pass
- [x] Code follows project standards
- [x] Auth check on DELETE route
- [x] RLS enforces ownership (only owner's video returned by select)
- [x] Storage cleanup after DB delete (non-blocking on failure)
- [x] Confirmation dialog before deletion