### PR TITLE
[#12] Implement ingestion pipeline status tracking

### DIFF
--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { UploadForm } from "@/components/videos/upload-form";
 import { VideoList } from "@/components/videos/video-list";
 import { Separator } from "@/components/ui/separator";
+import { isTerminalStatus } from "@/components/videos/pipeline-status";
 
 interface Video {
   id: string;
@@ -15,9 +16,12 @@ interface Video {
   created_at: string;
 }
 
+const POLL_INTERVAL = 5000; // 5 seconds
+
 export default function VideosPage() {
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(true);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchVideos = useCallback(async () => {
     const response = await fetch("/api/videos");
@@ -27,6 +31,27 @@ export default function VideosPage() {
     }
     setLoading(false);
   }, []);
+
+  // Poll when any video is in a non-terminal state
+  useEffect(() => {
+    const hasActiveVideos = videos.some(
+      (v) => !isTerminalStatus(v.status) && v.status !== "uploaded"
+    );
+
+    if (hasActiveVideos && !pollRef.current) {
+      pollRef.current = setInterval(fetchVideos, POLL_INTERVAL);
+    } else if (!hasActiveVideos && pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [videos, fetchVideos]);
 
   useEffect(() => {
     fetchVideos();

--- a/app/api/ingest/[videoId]/status/route.ts
+++ b/app/api/ingest/[videoId]/status/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ videoId: string }> }
+) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { videoId } = await params;
+
+  // RLS ensures only owner's video is returned
+  const { data: video, error } = await supabase
+    .from("videos")
+    .select("id, status, error_message")
+    .eq("id", videoId)
+    .single();
+
+  if (error || !video) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    videoId: video.id,
+    status: video.status,
+    error_message: video.error_message,
+  });
+}

--- a/components/videos/pipeline-status.tsx
+++ b/components/videos/pipeline-status.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+interface PipelineStatusProps {
+  status: string;
+  errorMessage?: string | null;
+}
+
+const statusConfig: Record<
+  string,
+  { label: string; className: string; icon: "dot" | "spinner" | "check" | "error" }
+> = {
+  uploaded: {
+    label: "Uploaded",
+    className: "text-muted-foreground",
+    icon: "dot",
+  },
+  transcribing: {
+    label: "Transcribing...",
+    className: "text-yellow-600",
+    icon: "spinner",
+  },
+  embedding: {
+    label: "Embedding...",
+    className: "text-blue-600",
+    icon: "spinner",
+  },
+  extracting: {
+    label: "Extracting knowledge...",
+    className: "text-blue-600",
+    icon: "spinner",
+  },
+  complete: {
+    label: "Complete",
+    className: "text-green-600",
+    icon: "check",
+  },
+  error: {
+    label: "Error",
+    className: "text-destructive",
+    icon: "error",
+  },
+};
+
+function StatusIcon({ type }: { type: "dot" | "spinner" | "check" | "error" }) {
+  switch (type) {
+    case "dot":
+      return (
+        <span className="inline-block w-2 h-2 rounded-full bg-muted-foreground" />
+      );
+    case "spinner":
+      return (
+        <span className="inline-block w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin" />
+      );
+    case "check":
+      return (
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      );
+    case "error":
+      return (
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      );
+  }
+}
+
+export function PipelineStatus({ status, errorMessage }: PipelineStatusProps) {
+  const config = statusConfig[status] ?? {
+    label: status,
+    className: "text-muted-foreground",
+    icon: "dot" as const,
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-0.5">
+      <div className={`flex items-center gap-1.5 ${config.className}`}>
+        <StatusIcon type={config.icon} />
+        <span className="text-xs font-medium">{config.label}</span>
+      </div>
+      {status === "error" && errorMessage && (
+        <span className="text-xs text-destructive max-w-48 text-right truncate">
+          {errorMessage}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Whether a status is terminal (no more updates expected) */
+export function isTerminalStatus(status: string): boolean {
+  return status === "complete" || status === "error";
+}

--- a/components/videos/video-list.tsx
+++ b/components/videos/video-list.tsx
@@ -3,12 +3,12 @@
 import { useState } from "react";
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { PipelineStatus } from "@/components/videos/pipeline-status";
 
 interface Video {
   id: string;
@@ -24,15 +24,6 @@ interface VideoListProps {
   videos: Video[];
   onDelete: () => void;
 }
-
-const statusLabels: Record<string, { label: string; className: string }> = {
-  uploaded: { label: "Uploaded", className: "text-muted-foreground" },
-  transcribing: { label: "Transcribing", className: "text-blue-600" },
-  embedding: { label: "Embedding", className: "text-blue-600" },
-  extracting: { label: "Extracting", className: "text-blue-600" },
-  complete: { label: "Complete", className: "text-green-600" },
-  error: { label: "Error", className: "text-destructive" },
-};
 
 export function VideoList({ videos, onDelete }: VideoListProps) {
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -70,44 +61,31 @@ export function VideoList({ videos, onDelete }: VideoListProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      {videos.map((video) => {
-        const status = statusLabels[video.status] ?? {
-          label: video.status,
-          className: "text-muted-foreground",
-        };
-
-        return (
-          <Card key={video.id}>
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base">{video.title}</CardTitle>
-                <div className="flex items-center gap-2">
-                  <span className={`text-xs font-medium ${status.className}`}>
-                    {status.label}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-muted-foreground hover:text-destructive h-7 px-2"
-                    onClick={() => handleDelete(video)}
-                    disabled={deleting === video.id}
-                  >
-                    {deleting === video.id ? "Deleting..." : "Delete"}
-                  </Button>
-                </div>
+      {videos.map((video) => (
+        <Card key={video.id}>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base">{video.title}</CardTitle>
+              <div className="flex items-center gap-3">
+                <PipelineStatus
+                  status={video.status}
+                  errorMessage={video.error_message}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-destructive h-7 px-2"
+                  onClick={() => handleDelete(video)}
+                  disabled={deleting === video.id}
+                >
+                  {deleting === video.id ? "Deleting..." : "Delete"}
+                </Button>
               </div>
-              <CardDescription>{video.filename}</CardDescription>
-            </CardHeader>
-            {video.error_message && (
-              <CardContent>
-                <p className="text-sm text-destructive">
-                  {video.error_message}
-                </p>
-              </CardContent>
-            )}
-          </Card>
-        );
-      })}
+            </div>
+            <CardDescription>{video.filename}</CardDescription>
+          </CardHeader>
+        </Card>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Ticket
Closes #12
Parent Epic: #2 — Video Ingestion Pipeline

## Summary
Adds pipeline status visibility so users can see the progress of their video ingestion. Includes a status API endpoint, a visual status component with distinct indicators for each state, and auto-polling on the videos page.

## Changes Made
- `app/api/ingest/[videoId]/status/route.ts` — GET endpoint returning `{ videoId, status, error_message }` with auth check and RLS ownership
- `components/videos/pipeline-status.tsx` — Visual status component with 6 states: uploaded (gray dot), transcribing (yellow spinner), embedding (blue spinner), extracting (blue spinner), complete (green check), error (red X + message). Exports `isTerminalStatus()` helper.
- `components/videos/video-list.tsx` — Replaced inline status labels with PipelineStatus component
- `app/(dashboard)/videos/page.tsx` — Auto-polls every 5 seconds when any video is actively processing (transcribing/embedding/extracting). Stops polling when all videos reach terminal state.

## Testing
### Automated Tests
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

### Manual Testing
- View /videos page with uploaded videos → see status indicators
- Manually update a video's status in Supabase to "transcribing" → polling starts, UI updates within 5 seconds
- Set status to "complete" → polling stops

## Checklist
- [x] All tests pass
- [x] Code follows project standards
- [x] Auth check on status endpoint
- [x] Polling starts/stops correctly based on video states
- [x] All 6 pipeline statuses have distinct visual indicators