### PR TITLE
[#44] Fix delete button not visible on errored videos

### DIFF
--- a/components/videos/video-list.tsx
+++ b/components/videos/video-list.tsx
@@ -86,9 +86,12 @@ export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
         return (
           <Card key={video.id}>
             <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base">{video.title}</CardTitle>
-                <div className="flex items-center gap-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <CardTitle className="text-base truncate">{video.title}</CardTitle>
+                  <CardDescription className="truncate">{video.filename}</CardDescription>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
                   <PipelineStatus
                     status={video.status}
                     errorMessage={video.error_message}
@@ -119,7 +122,6 @@ export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
                   </Button>
                 </div>
               </div>
-              <CardDescription>{video.filename}</CardDescription>
             </CardHeader>
           </Card>
         );


### PR DESCRIPTION
## Ticket
Closes #44
Parent Epic: #2 — Video Ingestion Pipeline

## Summary
Fix layout overflow that hid the Delete button on errored video cards. The status indicator, Retry button, and Delete button competed for space, pushing Delete off-screen.

## Changes Made
- `components/videos/video-list.tsx` — Fixed card layout:
  - `items-center` → `items-start` for top-aligned content
  - Added `shrink-0` on buttons container so it never collapses
  - Added `min-w-0` + `truncate` on title/filename to prevent overflow
  - Moved CardDescription inside the title container for cleaner layout

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

## Checklist
- [x] Delete button visible on all statuses (uploaded, transcribing, embedding, extracting, complete, error)
- [x] Retry + Delete both visible on errored videos
- [x] Long filenames truncate instead of pushing buttons off-screen