### PR TITLE
[#34] Prevent duplicate video uploads by content hash

### DIFF
--- a/app/api/videos/check-duplicate/route.ts
+++ b/app/api/videos/check-duplicate/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+
+export async function POST(request: Request) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { content_hash } = await request.json();
+
+  if (!content_hash) {
+    return NextResponse.json(
+      { error: "Missing required field: content_hash" },
+      { status: 400 }
+    );
+  }
+
+  const { data: existing } = await supabase
+    .from("videos")
+    .select("id, title")
+    .eq("user_id", user.id)
+    .eq("content_hash", content_hash)
+    .limit(1)
+    .single();
+
+  if (existing) {
+    return NextResponse.json({
+      duplicate: true,
+      existing_title: existing.title,
+    });
+  }
+
+  return NextResponse.json({ duplicate: false });
+}

--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json();
-  const { title, filename, storage_path } = body;
+  const { title, filename, storage_path, content_hash } = body;
 
   if (!title || !filename || !storage_path) {
     return NextResponse.json(
@@ -59,6 +59,7 @@ export async function POST(request: Request) {
       title,
       filename,
       storage_path,
+      content_hash: content_hash || null,
       status: "uploaded",
     })
     .select("id, title, filename, status, created_at")

--- a/components/videos/upload-form.tsx
+++ b/components/videos/upload-form.tsx
@@ -12,6 +12,32 @@ interface UploadFormProps {
   onUploadComplete: () => void;
 }
 
+/** Compute SHA-256 hash of a file using streaming reads */
+async function hashFile(file: File): Promise<string> {
+  const CHUNK_SIZE = 2 * 1024 * 1024; // 2MB chunks
+  const chunks: ArrayBuffer[] = [];
+  let offset = 0;
+
+  while (offset < file.size) {
+    const slice = file.slice(offset, offset + CHUNK_SIZE);
+    chunks.push(await slice.arrayBuffer());
+    offset += CHUNK_SIZE;
+  }
+
+  // Concatenate all chunks and hash
+  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+  const combined = new Uint8Array(totalLength);
+  let pos = 0;
+  for (const chunk of chunks) {
+    combined.set(new Uint8Array(chunk), pos);
+    pos += chunk.byteLength;
+  }
+
+  const hashBuffer = await crypto.subtle.digest("SHA-256", combined);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 export function UploadForm({ onUploadComplete }: UploadFormProps) {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -40,6 +66,40 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
     }
 
     setUploading(true);
+
+    // Step 1: Compute content hash
+    setProgress("Computing file hash...");
+    let contentHash: string;
+    try {
+      contentHash = await hashFile(file);
+    } catch {
+      setError("Failed to compute file hash.");
+      setUploading(false);
+      setProgress(null);
+      return;
+    }
+
+    // Step 2: Check for duplicate
+    setProgress("Checking for duplicates...");
+    const dupResponse = await fetch("/api/videos/check-duplicate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content_hash: contentHash }),
+    });
+
+    if (dupResponse.ok) {
+      const dupData = await dupResponse.json();
+      if (dupData.duplicate) {
+        setError(
+          `This video has already been uploaded as "${dupData.existing_title}".`
+        );
+        setUploading(false);
+        setProgress(null);
+        return;
+      }
+    }
+
+    // Step 3: Upload to storage
     setProgress("Uploading to storage...");
 
     const supabase = createBrowserClient();
@@ -54,7 +114,6 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
       return;
     }
 
-    // Upload directly to Supabase Storage from the browser
     const fileId = crypto.randomUUID();
     const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
     const storagePath = `${user.id}/${fileId}_${safeName}`;
@@ -73,7 +132,7 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
       return;
     }
 
-    // Create the database record via API
+    // Step 4: Create database record
     setProgress("Saving video record...");
 
     const response = await fetch("/api/videos", {
@@ -83,11 +142,11 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
         title: file.name.replace(/\.[^/.]+$/, ""),
         filename: file.name,
         storage_path: storagePath,
+        content_hash: contentHash,
       }),
     });
 
     if (!response.ok) {
-      // Clean up the uploaded file
       await supabase.storage.from("videos").remove([storagePath]);
       const data = await response.json();
       setError(data.error || "Failed to save video record.");
@@ -96,7 +155,6 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
       return;
     }
 
-    // Reset form and notify parent
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }

--- a/supabase/migrations/005_video_content_hash.sql
+++ b/supabase/migrations/005_video_content_hash.sql
@@ -1,0 +1,8 @@
+-- Add content_hash column for duplicate detection.
+-- SHA-256 hash computed client-side before upload.
+-- Nullable for existing rows that were uploaded before this feature.
+
+ALTER TABLE videos ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+-- Index for fast duplicate lookups scoped per user
+CREATE INDEX IF NOT EXISTS idx_videos_user_hash ON videos(user_id, content_hash);


### PR DESCRIPTION
## Ticket
Closes #34
Parent Epic: #2 — Video Ingestion Pipeline

## Summary
Prevents uploading the same video file twice using SHA-256 content hashing. The hash is computed client-side before upload, checked against existing videos, and stored with the record.

## Changes Made
- `supabase/migrations/005_video_content_hash.sql` — Adds `content_hash` column + `(user_id, content_hash)` index
- `app/api/videos/check-duplicate/route.ts` — POST endpoint: checks for existing video with matching hash for the user
- `components/videos/upload-form.tsx` — Computes SHA-256 hash via Web Crypto API (2MB chunks), checks for duplicate before upload, passes hash to API
- `app/api/videos/route.ts` — Accepts and stores `content_hash` with video record

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

## Checklist
- [x] Hash computed client-side (no server-side file processing)
- [x] Duplicate check happens before upload (saves bandwidth)
- [x] Duplicate scoped per user
- [x] Existing videos without hash (null) won't trigger false duplicates
- [x] Shows existing video title in error message