### PR TITLE
[#45] Refine extraction prompt for property population and type accuracy

### DIFF
--- a/lib/extraction-prompt.ts
+++ b/lib/extraction-prompt.ts
@@ -6,7 +6,12 @@ export function buildExtractionPrompt(
 ): string {
   const nodeTypes = ontologyEntries
     .filter((e) => e.category === "node_type")
-    .map((e) => `- ${e.name}: ${e.description || "No description"}`)
+    .map((e) => {
+      const schema = e.properties_schema
+        ? ` | Properties: ${JSON.stringify(e.properties_schema)}`
+        : "";
+      return `- ${e.name}: ${e.description || "No description"}${schema}`;
+    })
     .join("\n");
 
   const edgeTypes = ontologyEntries
@@ -18,7 +23,7 @@ export function buildExtractionPrompt(
 
 ## Ontology
 
-### Valid Node Types
+### Valid Node Types (with property schemas)
 ${nodeTypes}
 
 ### Valid Edge Types
@@ -27,13 +32,27 @@ ${edgeTypes}
 ## Rules
 
 1. Only use node types and edge types from the ontology above. Do not invent new types.
-2. Use concise, canonical labels for nodes (e.g., "Armbar" not "The armbar from closed guard").
-3. If the same technique/position is mentioned multiple times, use the same label consistently.
-4. Extract relationships between techniques — how they connect, transition, counter, or chain together.
-5. Include the instructor name if mentioned.
-6. Include the instructional title if mentioned.
-7. For properties, only include information explicitly stated in the transcription.
-8. Be thorough — extract all techniques, positions, and concepts discussed, not just the main ones.
+2. **Choose the most specific node type.** Use these guidelines:
+   - If something is a guard variant (closed guard, half guard, butterfly guard, K-guard, de la Riva, etc.), use "Guard" not "Technique".
+   - If something is a submission (armbar, kimura, triangle, heel hook, etc.), use "Submission" not "Technique".
+   - If something is a sweep (scissor sweep, hip bump, etc.), use "Sweep" not "Technique".
+   - If something is a guard pass (knee cut, torreando, leg drag, etc.), use "Pass" not "Technique".
+   - If something is a pin (kesa gatame, north-south, etc.), use "Pin" not "Technique" or "Position".
+   - If something is a takedown (single leg, double leg, osoto gari, etc.), use "Takedown" not "Technique".
+   - If something is a control position (mount, side control, back control, etc.), use "Position".
+   - Use "Technique" only for moves that don't fit a more specific type.
+   - Use "Concept" for principles, strategies, and abstract ideas (e.g., "posture breaking", "inside position", "connection").
+3. Use concise, canonical labels for nodes (e.g., "Armbar" not "The armbar from closed guard").
+4. If the same technique/position is mentioned multiple times, use the same label consistently.
+5. Extract relationships between techniques — how they connect, transition, counter, or chain together.
+6. Include the instructor name if mentioned. Use type "Instructor".
+7. Include the instructional title if mentioned. Use type "Instructional".
+8. **Populate properties** based on the property schema for each node type. For example:
+   - For a Guard node, set "open_closed" to "open" or "closed" if stated.
+   - For a Technique/Submission/Sweep/Pass, set "gi_nogi" to "gi", "nogi", or "both" if stated.
+   - For a Technique, set "belt_level" if the instructor mentions it (e.g., "fundamental", "advanced").
+   - Return properties as a JSON string: e.g., {"gi_nogi": "both"} or {} if no properties apply.
+9. Be thorough — extract all techniques, positions, and concepts discussed, not just the main ones.
 
 ## Transcription
 


### PR DESCRIPTION
## Ticket
Closes #45
Parent Epic: #3 — Knowledge Graph

## Summary
Refines the extraction prompt to produce higher quality graph data. The LLM now receives property schemas for each node type and explicit rules for choosing the most specific type (Guard over Technique for guard variants, etc.).

## Changes Made
- `lib/extraction-prompt.ts` — Updated prompt:
  - Node types now include `properties_schema` (e.g., Technique has `{"belt_level": "string", "gi_nogi": "string"}`)
  - Added type specificity rules: Guard > Technique for guards, Submission > Technique for submissions, etc.
  - Added property population instructions with examples
  - Covers all 11 node types with specific guidance

## Before/After (expected)
**Before:** `{ type: "Technique", label: "K-guard", properties: "{}" }`
**After:** `{ type: "Guard", label: "K-guard", properties: "{\"open_closed\": \"open\"}" }`

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors
- [x] Prompt-only change — no logic modifications

## Checklist
- [x] properties_schema included for each node type
- [x] Type specificity rules for all 11 node types
- [x] Property population examples
- [x] No changes to extraction logic or Zod schema