### PR TITLE
[#58] Fix chat input cut off at bottom of viewport

### DIFF
--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -38,7 +38,7 @@ export function ChatPanel() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-10rem)] max-w-2xl mx-auto">
+    <div className="flex flex-col h-[calc(100vh-12rem)] max-w-2xl mx-auto pb-4">
       {/* Messages */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-3 pb-4">
         {chat.messages.length === 0 && (


### PR DESCRIPTION
## Ticket
Closes #58
Parent Epic: #5 — Natural Language Chat

## Summary
Fix the chat input being clipped at the bottom of the viewport by increasing the height offset and adding bottom padding.

## Changes Made
- `components/chat/chat-panel.tsx` — Changed `h-[calc(100vh-10rem)]` to `h-[calc(100vh-12rem)]` and added `pb-4`

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

## Checklist
- [x] Input fully visible at bottom of viewport
- [x] No layout changes to other pages