### PR TITLE
[#61] Add instructor and instructional fields to video upload

### DIFF
--- a/app/api/ingest/[videoId]/route.ts
+++ b/app/api/ingest/[videoId]/route.ts
@@ -24,7 +24,7 @@ export async function POST(
   // Fetch video (RLS ensures ownership)
   const { data: video, error: fetchError } = await supabase
     .from("videos")
-    .select("id, storage_path, status")
+    .select("id, storage_path, status, instructor, instructional")
     .eq("id", videoId)
     .single();
 
@@ -53,7 +53,10 @@ export async function POST(
   );
 
   // Run full pipeline in the background
-  runPipeline(supabase, user.id, video.id, video.storage_path).catch((err) => {
+  runPipeline(supabase, user.id, video.id, video.storage_path, {
+    instructor: video.instructor,
+    instructional: video.instructional,
+  }).catch((err) => {
     console.error(`Pipeline failed for video ${videoId}:`, err);
   });
 
@@ -64,7 +67,8 @@ async function runPipeline(
   supabase: Awaited<ReturnType<typeof createServerClient>>,
   userId: string,
   videoId: string,
-  storagePath: string
+  storagePath: string,
+  metadata: { instructor?: string | null; instructional?: string | null }
 ) {
   try {
     // ── Step 1: Transcribe ──────────────────────────────────────────
@@ -164,7 +168,7 @@ async function runPipeline(
       throw new Error("No ontology entries found — run seed.sql first");
     }
 
-    const extraction = await extractKnowledge(result.text, ontologyEntries);
+    const extraction = await extractKnowledge(result.text, ontologyEntries, metadata);
     console.log(
       `Extracted ${extraction.nodes.length} nodes, ${extraction.edges.length} edges for video ${videoId}`
     );

--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json();
-  const { title, filename, storage_path, content_hash } = body;
+  const { title, filename, storage_path, content_hash, instructor, instructional } = body;
 
   if (!title || !filename || !storage_path) {
     return NextResponse.json(
@@ -60,6 +60,8 @@ export async function POST(request: Request) {
       filename,
       storage_path,
       content_hash: content_hash || null,
+      instructor: instructor || null,
+      instructional: instructional || null,
       status: "uploaded",
     })
     .select("id, title, filename, status, created_at")

--- a/components/videos/upload-form.tsx
+++ b/components/videos/upload-form.tsx
@@ -42,6 +42,8 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<string | null>(null);
+  const [instructor, setInstructor] = useState("");
+  const [instructional, setInstructional] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -143,6 +145,8 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
         filename: file.name,
         storage_path: storagePath,
         content_hash: contentHash,
+        instructor: instructor.trim() || null,
+        instructional: instructional.trim() || null,
       }),
     });
 
@@ -158,6 +162,8 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
+    setInstructor("");
+    setInstructional("");
     setUploading(false);
     setProgress(null);
     onUploadComplete();
@@ -174,6 +180,30 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
           ref={fileInputRef}
           disabled={uploading}
         />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="instructor">Instructor</Label>
+          <Input
+            id="instructor"
+            type="text"
+            placeholder="e.g., John Danaher"
+            value={instructor}
+            onChange={(e) => setInstructor(e.target.value)}
+            disabled={uploading}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="instructional">Instructional</Label>
+          <Input
+            id="instructional"
+            type="text"
+            placeholder="e.g., Enter the System"
+            value={instructional}
+            onChange={(e) => setInstructional(e.target.value)}
+            disabled={uploading}
+          />
+        </div>
       </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
       {progress && (

--- a/lib/extraction-prompt.ts
+++ b/lib/extraction-prompt.ts
@@ -1,8 +1,10 @@
 import type { OntologyEntry } from "@/lib/ontology";
+import type { VideoMetadata } from "@/lib/extraction";
 
 export function buildExtractionPrompt(
   ontologyEntries: OntologyEntry[],
-  transcriptionText: string
+  transcriptionText: string,
+  metadata?: VideoMetadata
 ): string {
   const nodeTypes = ontologyEntries
     .filter((e) => e.category === "node_type")
@@ -53,7 +55,11 @@ ${edgeTypes}
    - For a Technique, set "belt_level" if the instructor mentions it (e.g., "fundamental", "advanced").
    - Return properties as a JSON string: e.g., {"gi_nogi": "both"} or {} if no properties apply.
 9. Be thorough — extract all techniques, positions, and concepts discussed, not just the main ones.
-
+${metadata?.instructor || metadata?.instructional ? `
+## Video Metadata
+${metadata.instructor ? `- **Instructor:** ${metadata.instructor}. Create an Instructor node with this name. Connect ALL extracted techniques, positions, submissions, sweeps, guards, passes, pins, and takedowns to this instructor via TAUGHT_BY edges.` : ""}
+${metadata.instructional ? `- **Instructional:** ${metadata.instructional}. Create an Instructional node with this name. Connect ALL extracted techniques, positions, submissions, sweeps, guards, passes, pins, and takedowns to this instructional via APPEARS_IN edges.` : ""}
+` : ""}
 ## Transcription
 
 ${transcriptionText}

--- a/lib/extraction.ts
+++ b/lib/extraction.ts
@@ -30,9 +30,15 @@ export type ExtractionResult = z.infer<typeof extractionSchema>;
  * Extract knowledge graph nodes and edges from transcription text
  * using the ontology as a constraint schema.
  */
+export interface VideoMetadata {
+  instructor?: string | null;
+  instructional?: string | null;
+}
+
 export async function extractKnowledge(
   transcriptionText: string,
-  ontologyEntries: OntologyEntry[]
+  ontologyEntries: OntologyEntry[],
+  metadata?: VideoMetadata
 ): Promise<ExtractionResult> {
   const validNodeTypes = new Set(
     ontologyEntries.filter((e) => e.category === "node_type").map((e) => e.name)
@@ -47,7 +53,7 @@ export async function extractKnowledge(
   const allEdges: ExtractionResult["edges"] = [];
 
   for (const chunk of textChunks) {
-    const prompt = buildExtractionPrompt(ontologyEntries, chunk);
+    const prompt = buildExtractionPrompt(ontologyEntries, chunk, metadata);
 
     const { object } = await generateObject({
       model: openai("gpt-4o"),

--- a/supabase/migrations/006_video_metadata.sql
+++ b/supabase/migrations/006_video_metadata.sql
@@ -1,0 +1,6 @@
+-- Add instructor and instructional metadata to videos table.
+-- Users tag these at upload time so the extraction pipeline can
+-- create reliable Instructor/Instructional nodes and edges.
+
+ALTER TABLE videos ADD COLUMN IF NOT EXISTS instructor TEXT;
+ALTER TABLE videos ADD COLUMN IF NOT EXISTS instructional TEXT;


### PR DESCRIPTION
## Ticket
Closes #61
Parent Epic: #2 — Video Ingestion Pipeline

## Summary
Users can now tag instructor and instructional series when uploading videos. The extraction pipeline uses this metadata to reliably create Instructor and Instructional nodes with TAUGHT_BY and APPEARS_IN edges, fixing the issue where instructors weren't detected from audio and instructional nodes floated disconnected.

## Changes Made
- `supabase/migrations/006_video_metadata.sql` — Adds `instructor` and `instructional` columns (TEXT, nullable)
- `components/videos/upload-form.tsx` — Optional text inputs for instructor and instructional
- `app/api/videos/route.ts` — Accepts and stores both fields
- `lib/extraction.ts` — New `VideoMetadata` interface, `extractKnowledge` accepts optional metadata
- `lib/extraction-prompt.ts` — Adds "Video Metadata" section to prompt when available, with explicit instructions to create TAUGHT_BY and APPEARS_IN edges for ALL extracted nodes
- `app/api/ingest/[videoId]/route.ts` — Fetches metadata from video record, passes through pipeline to extraction

## Testing
- [x] All tests pass (6/6)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors

## Checklist
- [x] Both fields optional
- [x] Metadata passed through full pipeline: upload → ingest → extraction prompt
- [x] Prompt explicitly instructs TAUGHT_BY + APPEARS_IN edges for all techniques
- [x] Fields reset after upload
- [x] No changes to extraction logic — prompt-only