### PR TITLE
chore: rename Jiujitsology to JiuJitsology across codebase

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -30,7 +30,7 @@ You are a Senior Full-Stack Engineer. Your primary responsibility is to autonomo
 
 ## Project Context
 
-- **Product**: Jiujitsology — B2C knowledge graph for BJJ instructional video libraries
+- **Product**: JiuJitsology — B2C knowledge graph for BJJ instructional video libraries
 - **Platform**: Web application (Next.js 15, App Router) deployed on Render
 - **Tech Stack**: TypeScript 5.x, React 19, Tailwind CSS, shadcn/ui, Cytoscape.js (react-cytoscapejs), graphology, Vercel AI SDK, Supabase (PostgreSQL + Auth + Storage), OpenAI Whisper API
 - **Architecture**: Monolith (Next.js API routes + React frontend). Knowledge graph stored as nodes/edges tables in Supabase, loaded into graphology for in-memory traversal.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -49,7 +49,7 @@ You are a Staff Engineer and Tech Lead responsible for maintaining the highest q
 
 ## Project Context
 
-- **Product**: Jiujitsology — B2C knowledge graph for BJJ instructional video libraries
+- **Product**: JiuJitsology — B2C knowledge graph for BJJ instructional video libraries
 - **Platform**: Web application (Next.js 15, App Router) deployed on Render
 - **Tech Stack**: TypeScript 5.x, React 19, Tailwind CSS, shadcn/ui, Cytoscape.js, graphology, Vercel AI SDK, Supabase (PostgreSQL + Auth + Storage), OpenAI Whisper API
 - **Quality Standards**:

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -151,7 +151,7 @@ You are a master of:
 
 ## Project-Specific Context
 
-- **Product**: Jiujitsology — B2C knowledge graph for BJJ instructional video libraries
+- **Product**: JiuJitsology — B2C knowledge graph for BJJ instructional video libraries
 - **Architecture**: Next.js 15 (App Router) monolith on Render, Supabase (PostgreSQL + Auth + Storage)
 - **Testing Stack**: Vitest + React Testing Library (frontend), Vitest (API routes)
 - **Key Test Areas**:

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -415,7 +415,7 @@ Use the **ATAM (Architecture Tradeoff Analysis Method)**:
 
 ### Product
 
-Jiujitsology — B2C web application that builds a knowledge graph from BJJ instructional video transcriptions, enabling natural language querying and graph-based exploration.
+JiuJitsology — B2C web application that builds a knowledge graph from BJJ instructional video transcriptions, enabling natural language querying and graph-based exploration.
 
 ### Bounded Contexts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ TEMPLATE: Fill in project-specific details below when using this template.
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
-- **Project Name**: Jiujitsology
+- **Project Name**: JiuJitsology
 - **Repository**: https://github.com/tck517/jiujitsology
 - **Project Board**: https://github.com/users/tck517/projects/8
 - **Tech Stack**: Next.js 15, TypeScript, Tailwind CSS, shadcn/ui, Cytoscape.js, graphology, Vercel AI SDK

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -46,7 +46,7 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <CardTitle className="text-2xl">Welcome to Jiujitsology</CardTitle>
+          <CardTitle className="text-2xl">Welcome to JiuJitsology</CardTitle>
           <CardDescription>
             Enter your email to sign in or create an account. We&apos;ll
             send you a magic link — no password needed.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
-  title: "Jiujitsology",
+  title: "JiuJitsology",
   description:
     "Organize and query your BJJ instructional video library with a knowledge graph",
 };

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -56,7 +56,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex h-14 items-center px-4 md:px-6">
           <Link href="/" className="mr-6 font-bold text-lg">
-            Jiujitsology
+            JiuJitsology
           </Link>
 
           {/* Desktop nav */}

--- a/docs/PRODUCT-REQUIREMENTS.md
+++ b/docs/PRODUCT-REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 ## Product Overview
 
-- **Name**: Jiujitsology
+- **Name**: JiuJitsology
 - **Type**: Web application
 - **Category**: B2C Consumer app
 - **Domain**: A knowledge graph tool for organizing, searching, and summarizing BJJ instructional video libraries

--- a/docs/PRODUCT-ROADMAP.md
+++ b/docs/PRODUCT-ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Jiujitsology will launch as an MVP within 2-3 months, focused on delivering a knowledge graph-powered learning tool for BJJ instructional video libraries. The product is budget-constrained, hosted on Render with Supabase, and targets 10 active users in the first 3 months post-launch.
+JiuJitsology will launch as an MVP within 2-3 months, focused on delivering a knowledge graph-powered learning tool for BJJ instructional video libraries. The product is budget-constrained, hosted on Render with Supabase, and targets 10 active users in the first 3 months post-launch.
 
 ## Phase 1: MVP
 

--- a/docs/TECHNICAL-ARCHITECTURE.md
+++ b/docs/TECHNICAL-ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Jiujitsology is a Next.js web application that ingests BJJ instructional videos, extracts transcriptions, builds a knowledge graph from the extracted content, and exposes that graph through an interactive visualization and natural language chat interface. The system is deployed on Render with Supabase as the primary database and auth provider.
+JiuJitsology is a Next.js web application that ingests BJJ instructional videos, extracts transcriptions, builds a knowledge graph from the extracted content, and exposes that graph through an interactive visualization and natural language chat interface. The system is deployed on Render with Supabase as the primary database and auth provider.
 
 ## Technology Stack
 

--- a/lib/chat-context.ts
+++ b/lib/chat-context.ts
@@ -101,7 +101,7 @@ export async function buildChatContext(
 }
 
 export function buildSystemPrompt(context: GraphContext): string {
-  let prompt = `You are Jiujitsology, an AI assistant specialized in Brazilian Jiu-Jitsu. You help users understand and explore their BJJ instructional video library.
+  let prompt = `You are JiuJitsology, an AI assistant specialized in Brazilian Jiu-Jitsu. You help users understand and explore their BJJ instructional video library.
 
 You have access to:
 1. A knowledge graph of BJJ techniques, positions, and their relationships extracted from the user's instructional videos.

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,4 +1,4 @@
--- Jiujitsology Initial Schema
+-- JiuJitsology Initial Schema
 -- Creates all core tables, RLS policies, and indexes.
 
 -- =============================================================================


### PR DESCRIPTION
## Summary
- Renamed "Jiujitsology" to "JiuJitsology" (capital J in Jitsu) across 13 files
- Updated: nav bar, login page, browser tab title, chat system prompt, all docs, agent configs, migration comment
- Preserved: repository name/URLs (lowercase), package.json name, session journals (historical records)

Closes #72

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: verify nav bar shows "JiuJitsology"
- [ ] Manual: verify login page shows "Welcome to JiuJitsology"
- [ ] Manual: verify browser tab shows "JiuJitsology"

Generated with Claude Code
