### PR TITLE
feat(videos): group video list by instructor and instructional with ellipsis

### DIFF
--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -14,6 +14,8 @@ interface Video {
   duration_sec: number | null;
   error_message: string | null;
   created_at: string;
+  instructor: string | null;
+  instructional: string | null;
 }
 
 const POLL_INTERVAL = 5000; // 5 seconds

--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -13,8 +13,10 @@ export async function GET() {
 
   const { data: videos, error } = await supabase
     .from("videos")
-    .select("id, title, filename, status, duration_sec, error_message, created_at")
+    .select("id, title, filename, status, duration_sec, error_message, created_at, instructor, instructional")
     .eq("user_id", user.id)
+    .order("instructor", { ascending: true, nullsFirst: false })
+    .order("instructional", { ascending: true, nullsFirst: false })
     .order("created_at", { ascending: false });
 
   if (error) {

--- a/components/videos/video-list.tsx
+++ b/components/videos/video-list.tsx
@@ -18,6 +18,8 @@ interface Video {
   duration_sec: number | null;
   error_message: string | null;
   created_at: string;
+  instructor: string | null;
+  instructional: string | null;
 }
 
 interface VideoListProps {
@@ -26,9 +28,96 @@ interface VideoListProps {
   onRefresh: () => void;
 }
 
+const MAX_VISIBLE = 5;
+
+// Deterministic color from a string — maps to a fixed Tailwind palette
+const BADGE_COLORS = [
+  "bg-blue-100 text-blue-800",
+  "bg-emerald-100 text-emerald-800",
+  "bg-amber-100 text-amber-800",
+  "bg-purple-100 text-purple-800",
+  "bg-rose-100 text-rose-800",
+  "bg-cyan-100 text-cyan-800",
+  "bg-orange-100 text-orange-800",
+  "bg-indigo-100 text-indigo-800",
+];
+
+function colorForName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return BADGE_COLORS[Math.abs(hash) % BADGE_COLORS.length];
+}
+
+interface InstructionalGroup {
+  instructional: string;
+  videos: Video[];
+}
+
+interface InstructorGroup {
+  instructor: string;
+  color: string;
+  instructionals: InstructionalGroup[];
+}
+
+function groupVideos(videos: Video[]): {
+  groups: InstructorGroup[];
+  ungrouped: Video[];
+} {
+  const ungrouped: Video[] = [];
+  const instructorMap = new Map<string, Map<string, Video[]>>();
+
+  for (const video of videos) {
+    if (!video.instructor) {
+      ungrouped.push(video);
+      continue;
+    }
+    const instrName = video.instructor;
+    const instrlName = video.instructional || "Uncategorized";
+
+    if (!instructorMap.has(instrName)) {
+      instructorMap.set(instrName, new Map());
+    }
+    const instrMap = instructorMap.get(instrName)!;
+    if (!instrMap.has(instrlName)) {
+      instrMap.set(instrlName, []);
+    }
+    instrMap.get(instrlName)!.push(video);
+  }
+
+  const groups: InstructorGroup[] = [];
+  for (const [instructor, instrMap] of instructorMap) {
+    const instructionals: InstructionalGroup[] = [];
+    for (const [instructional, vids] of instrMap) {
+      instructionals.push({ instructional, videos: vids });
+    }
+    groups.push({
+      instructor,
+      color: colorForName(instructor),
+      instructionals,
+    });
+  }
+
+  return { groups, ungrouped };
+}
+
 export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [ingesting, setIngesting] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggleExpand(key: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
 
   async function handleDelete(video: Video) {
     const confirmed = window.confirm(
@@ -68,6 +157,86 @@ export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
     onRefresh();
   }
 
+  function renderVideoCard(video: Video) {
+    const canIngest =
+      video.status === "uploaded" || video.status === "error";
+
+    return (
+      <Card key={video.id}>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">{video.title}</CardTitle>
+            <div className="flex items-center gap-3">
+              <PipelineStatus
+                status={video.status}
+                errorMessage={video.error_message}
+              />
+              {canIngest && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2"
+                  onClick={() => handleIngest(video)}
+                  disabled={ingesting === video.id}
+                >
+                  {ingesting === video.id
+                    ? "Starting..."
+                    : video.status === "error"
+                      ? "Retry"
+                      : "Ingest"}
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-destructive h-7 px-2"
+                onClick={() => handleDelete(video)}
+                disabled={deleting === video.id}
+              >
+                {deleting === video.id ? "Deleting..." : "Delete"}
+              </Button>
+            </div>
+          </div>
+          <CardDescription>{video.filename}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  function renderInstructionalGroup(
+    group: InstructionalGroup,
+    groupKey: string
+  ) {
+    const isExpanded = expanded.has(groupKey);
+    const visibleVideos = isExpanded
+      ? group.videos
+      : group.videos.slice(0, MAX_VISIBLE);
+    const hiddenCount = group.videos.length - MAX_VISIBLE;
+
+    return (
+      <div key={groupKey} className="flex flex-col gap-2">
+        <p className="text-sm font-medium text-muted-foreground">
+          {group.instructional}
+          <span className="ml-2 text-xs font-normal">
+            ({group.videos.length} {group.videos.length === 1 ? "video" : "videos"})
+          </span>
+        </p>
+        {visibleVideos.map(renderVideoCard)}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            className="text-sm text-primary hover:underline text-left px-1"
+            onClick={() => toggleExpand(groupKey)}
+          >
+            {isExpanded
+              ? "Show less"
+              : `Show ${hiddenCount} more...`}
+          </button>
+        )}
+      </div>
+    );
+  }
+
   if (videos.length === 0) {
     return (
       <p className="text-muted-foreground text-sm">
@@ -77,53 +246,41 @@ export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
     );
   }
 
-  return (
-    <div className="flex flex-col gap-3">
-      {videos.map((video) => {
-        const canIngest =
-          video.status === "uploaded" || video.status === "error";
+  const { groups, ungrouped } = groupVideos(videos);
 
-        return (
-          <Card key={video.id}>
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base">{video.title}</CardTitle>
-                <div className="flex items-center gap-3">
-                  <PipelineStatus
-                    status={video.status}
-                    errorMessage={video.error_message}
-                  />
-                  {canIngest && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      onClick={() => handleIngest(video)}
-                      disabled={ingesting === video.id}
-                    >
-                      {ingesting === video.id
-                        ? "Starting..."
-                        : video.status === "error"
-                          ? "Retry"
-                          : "Ingest"}
-                    </Button>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-muted-foreground hover:text-destructive h-7 px-2"
-                    onClick={() => handleDelete(video)}
-                    disabled={deleting === video.id}
-                  >
-                    {deleting === video.id ? "Deleting..." : "Delete"}
-                  </Button>
-                </div>
-              </div>
-              <CardDescription>{video.filename}</CardDescription>
-            </CardHeader>
-          </Card>
-        );
-      })}
+  return (
+    <div className="flex flex-col gap-6">
+      {groups.map((group) => (
+        <div key={group.instructor} className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-block rounded-full px-3 py-1 text-xs font-semibold ${group.color}`}
+            >
+              {group.instructor}
+            </span>
+          </div>
+          <div className="flex flex-col gap-4 pl-2">
+            {group.instructionals.map((ig) =>
+              renderInstructionalGroup(
+                ig,
+                `${group.instructor}::${ig.instructional}`
+              )
+            )}
+          </div>
+        </div>
+      ))}
+      {ungrouped.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {groups.length > 0 && (
+            <p className="text-sm font-medium text-muted-foreground">
+              Ungrouped
+            </p>
+          )}
+          <div className="flex flex-col gap-2">
+            {ungrouped.map(renderVideoCard)}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Videos are now grouped by instructor (color-coded badge), then by instructional within each instructor
- Videos from different instructionals are never intermingled within an instructor group
- Groups with more than 5 videos collapse with a "Show N more..." toggle to prevent screen domination
- API now returns `instructor` and `instructional` fields, sorted by instructor then instructional then date
- Ungrouped videos (no instructor metadata) appear at the bottom
- Deterministic badge colors: same instructor always gets the same color across sessions

Closes #73

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: upload videos with same instructor/different instructionals — confirm separate subgroups
- [ ] Manual: upload 6+ videos with same instructor/instructional — confirm "Show 1 more..." appears
- [ ] Manual: click "Show N more..." — confirm all videos appear; click "Show less" to collapse
- [ ] Manual: videos with no instructor appear ungrouped at bottom

Generated with Claude Code
