### PR TITLE
feat(upload): make instructor and instructional required fields

### DIFF
--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -46,6 +46,13 @@ export async function POST(request: Request) {
     );
   }
 
+  if (!instructor?.trim() || !instructional?.trim()) {
+    return NextResponse.json(
+      { error: "Missing required fields: instructor, instructional" },
+      { status: 400 }
+    );
+  }
+
   // Verify the storage path is scoped to this user
   if (!storage_path.startsWith(`${user.id}/`)) {
     return NextResponse.json(

--- a/components/videos/upload-form.tsx
+++ b/components/videos/upload-form.tsx
@@ -98,6 +98,16 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
       return;
     }
 
+    if (!instructor.trim()) {
+      setError("Instructor is required.");
+      return;
+    }
+
+    if (!instructional.trim()) {
+      setError("Instructional is required.");
+      return;
+    }
+
     if (file.size > MAX_FILE_SIZE) {
       setError("File size exceeds 5GB limit.");
       return;
@@ -224,7 +234,7 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="instructor">Instructor</Label>
+          <Label htmlFor="instructor">Instructor <span className="text-destructive">*</span></Label>
           <Input
             id="instructor"
             type="text"
@@ -232,10 +242,11 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
             value={instructor}
             onChange={(e) => setInstructor(e.target.value)}
             disabled={uploading}
+            required
           />
         </div>
         <div className="flex flex-col gap-2">
-          <Label htmlFor="instructional">Instructional</Label>
+          <Label htmlFor="instructional">Instructional <span className="text-destructive">*</span></Label>
           <Input
             id="instructional"
             type="text"
@@ -243,6 +254,7 @@ export function UploadForm({ onUploadComplete }: UploadFormProps) {
             value={instructional}
             onChange={(e) => setInstructional(e.target.value)}
             disabled={uploading}
+            required
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Instructor and instructional fields are now required before upload can start
- Client-side: validation error shown if either field is empty, red asterisk on labels, HTML `required` attribute
- Server-side: POST `/api/videos` returns 400 if instructor or instructional is missing or empty
- Existing videos with null instructor/instructional are unaffected (no DB migration)

Closes #76

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: try uploading with empty instructor — confirm "Instructor is required." error
- [ ] Manual: try uploading with empty instructional — confirm "Instructional is required." error
- [ ] Manual: fill both fields and upload — confirm upload proceeds normally

Generated with Claude Code
