### PR TITLE
feat(graph): add instructional filter for cross-instructor comparison

### DIFF
--- a/app/api/graph/route.ts
+++ b/app/api/graph/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
   // Load nodes (filtered by type if specified)
   let nodesQuery = supabase
     .from("nodes")
-    .select("id, type, label, properties, source_video_id, videos(title)")
+    .select("id, type, label, properties, source_video_id, videos(title, instructional)")
     .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(limit);
@@ -57,7 +57,8 @@ export async function GET(request: Request) {
       label: n.label,
       properties: (n.properties as Record<string, unknown>) || {},
       source_video_id: n.source_video_id,
-      source_video_title: (Array.isArray(n.videos) ? n.videos[0]?.title : (n.videos as { title: string } | null)?.title) || null,
+      source_video_title: (Array.isArray(n.videos) ? n.videos[0]?.title : (n.videos as { title: string; instructional: string } | null)?.title) || null,
+      source_instructional: (Array.isArray(n.videos) ? n.videos[0]?.instructional : (n.videos as { title: string; instructional: string } | null)?.instructional) || null,
     })),
     (edges || []).map((e) => ({ ...e, properties: (e.properties as Record<string, unknown>) || {} }))
   );

--- a/components/graph/graph-controls.tsx
+++ b/components/graph/graph-controls.tsx
@@ -16,6 +16,9 @@ interface GraphControlsProps {
   instructors: string[];
   selectedInstructors: Set<string>;
   onToggleInstructor: (name: string) => void;
+  instructionals: string[];
+  selectedInstructionals: Set<string>;
+  onToggleInstructional: (name: string) => void;
 }
 
 const layouts = [
@@ -37,6 +40,9 @@ export function GraphControls({
   instructors,
   selectedInstructors,
   onToggleInstructor,
+  instructionals,
+  selectedInstructionals,
+  onToggleInstructional,
 }: GraphControlsProps) {
   return (
     <div className="flex flex-col gap-4 p-4 border rounded-lg bg-card">
@@ -91,6 +97,63 @@ export function GraphControls({
                 <span
                   className={
                     selectedInstructors.size === 0 || selectedInstructors.has(name)
+                      ? "text-foreground"
+                      : "text-muted-foreground"
+                  }
+                >
+                  {name}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {instructionals.length > 0 && (
+        <div>
+          <Label className="text-xs font-medium mb-2 block">
+            Instructionals{" "}
+            {selectedInstructionals.size > 0 && (
+              <span className="text-muted-foreground font-normal">
+                ({selectedInstructionals.size} selected)
+              </span>
+            )}
+          </Label>
+          <div className="flex flex-col gap-1">
+            {instructionals.map((name) => (
+              <button
+                key={name}
+                className="flex items-center gap-2 text-xs hover:bg-accent rounded px-1 py-0.5"
+                onClick={() => onToggleInstructional(name)}
+              >
+                <span
+                  className="w-3 h-3 rounded-sm border shrink-0 flex items-center justify-center"
+                  style={{
+                    backgroundColor: selectedInstructionals.has(name)
+                      ? "#6b7280"
+                      : "transparent",
+                    borderColor: "#6b7280",
+                  }}
+                >
+                  {selectedInstructionals.has(name) && (
+                    <svg
+                      className="w-2 h-2 text-white"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={3}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  )}
+                </span>
+                <span
+                  className={
+                    selectedInstructionals.size === 0 || selectedInstructionals.has(name)
                       ? "text-foreground"
                       : "text-muted-foreground"
                   }

--- a/components/graph/graph-explorer.tsx
+++ b/components/graph/graph-explorer.tsx
@@ -21,6 +21,7 @@ interface GraphNode {
   properties: Record<string, unknown>;
   source_video_id?: string | null;
   source_video_title?: string | null;
+  source_instructional?: string | null;
 }
 
 interface GraphEdge {
@@ -47,6 +48,7 @@ export function GraphExplorer() {
   const [layout, setLayout] = useState("cose");
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(new Set());
   const [selectedInstructors, setSelectedInstructors] = useState<Set<string>>(new Set());
+  const [selectedInstructionals, setSelectedInstructionals] = useState<Set<string>>(new Set());
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const cyRef = useRef<cytoscape.Core | null>(null);
 
@@ -122,10 +124,27 @@ export function GraphExplorer() {
     return allConnected;
   })();
 
+  // Build instructional list from nodes within the instructor-filtered set
+  const instructionals = (() => {
+    if (selectedInstructors.size === 0) return [];
+    const set = new Set<string>();
+    for (const node of nodes) {
+      if (node.source_instructional && (!instructorFilteredIds || instructorFilteredIds.has(node.id))) {
+        set.add(node.source_instructional);
+      }
+    }
+    return Array.from(set).sort();
+  })();
+
   // Build Cytoscape elements from filtered data
   const filteredNodes = nodes.filter((n) => {
     if (!visibleTypes.has(n.type)) return false;
     if (instructorFilteredIds && !instructorFilteredIds.has(n.id)) return false;
+    // Instructional filter: if instructionals are selected, only show nodes
+    // from those instructionals (plus nodes without a source_instructional
+    // that are connected via edges to matching nodes — handled by keeping
+    // non-instructional nodes like Instructor, Position, Concept visible).
+    if (selectedInstructionals.size > 0 && n.source_instructional && !selectedInstructionals.has(n.source_instructional)) return false;
     return true;
   });
   const filteredNodeIds = new Set(filteredNodes.map((n) => n.id));
@@ -165,6 +184,21 @@ export function GraphExplorer() {
 
   function handleToggleInstructor(name: string) {
     setSelectedInstructors((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      // Clear instructional selection when instructors change —
+      // the available instructionals depend on which instructors are selected.
+      setSelectedInstructionals(new Set());
+      return next;
+    });
+  }
+
+  function handleToggleInstructional(name: string) {
+    setSelectedInstructionals((prev) => {
       const next = new Set(prev);
       if (next.has(name)) {
         next.delete(name);
@@ -260,6 +294,9 @@ export function GraphExplorer() {
           instructors={instructors}
           selectedInstructors={selectedInstructors}
           onToggleInstructor={handleToggleInstructor}
+          instructionals={instructionals}
+          selectedInstructionals={selectedInstructionals}
+          onToggleInstructional={handleToggleInstructional}
         />
 
         {selectedNode && (

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -7,6 +7,7 @@ export interface GraphNode {
   properties: Record<string, unknown>;
   source_video_id?: string | null;
   source_video_title?: string | null;
+  source_instructional?: string | null;
 }
 
 export interface GraphEdge {


### PR DESCRIPTION
## Summary
- Added instructional filter to graph explorer as a second-level filter below instructors
- API now joins `videos(title, instructional)` and passes `source_instructional` on each node
- Instructional filter appears only when instructors are selected (hidden otherwise)
- Multi-select support: compare Danaher's Back Attacks vs Kimura System, or Brian Glick vs Nicky Ryan on open guard
- Instructional selection resets when instructor selection changes (dependent filter)
- Nodes without a `source_instructional` (like Instructor, Position nodes) remain visible when instructional filter is active

Closes #83

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: select an instructor — confirm instructional filter appears with that instructor's instructionals
- [ ] Manual: select one instructional — confirm graph narrows to nodes from that instructional
- [ ] Manual: select two instructionals — confirm union of both subgraphs shows
- [ ] Manual: deselect all instructionals — confirm full instructor subgraph returns
- [ ] Manual: deselect all instructors — confirm instructional filter hides

Generated with Claude Code
