### PR TITLE
chore: update codebase references after repo transfer to feature-x org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,15 +145,15 @@ TEMPLATE: Fill in project-specific details below when using this template.
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
 - **Project Name**: JiuJitsology
-- **Repository**: https://github.com/tck517/jiujitsology
-- **Project Board**: https://github.com/users/tck517/projects/8
+- **Repository**: https://github.com/feature-x/jiujitsology
+- **Project Board**: https://github.com/orgs/feature-x/projects/24
 - **Tech Stack**: Next.js 15, TypeScript, Tailwind CSS, shadcn/ui, Cytoscape.js, graphology, Vercel AI SDK
 - **Database**: Supabase (PostgreSQL + Auth + Storage)
 - **Transcription**: OpenAI Whisper API
 - **LLM**: Vercel AI SDK (provider-agnostic, starting with OpenAI or Anthropic)
 - **Graph Visualization**: Cytoscape.js (react-cytoscapejs)
 - **Hosting**: Render (free tier, standalone Next.js)
-- **Organization**: tck517
+- **Organization**: feature-x
 
 ### Build & Test Commands
 

--- a/docs/AGENT-WORKFLOW-SUMMARY.md
+++ b/docs/AGENT-WORKFLOW-SUMMARY.md
@@ -687,7 +687,7 @@ Human actions:
 # Output shows:
 # - va-worker created PR #60
 # - va-reviewer posted review
-# - tck517 (human) merged PR
+# - feature-x (human) merged PR
 # - No restricted actions detected
 ```
 


### PR DESCRIPTION
## Summary
- Updated repository URL from `tck517/jiujitsology` to `feature-x/jiujitsology` in CLAUDE.md
- Updated project board URL from `users/tck517/projects/8` to `orgs/feature-x/projects/24`
- Updated organization field from `tck517` to `feature-x`
- Updated example comment in AGENT-WORKFLOW-SUMMARY.md

Closes #87

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [x] grep for "tck517" returns zero matches in tracked files

Generated with Claude Code
