### PR TITLE
feat(video): add video player with signed URL playback from graph nodes

### DIFF
--- a/app/api/videos/[id]/signed-url/route.ts
+++ b/app/api/videos/[id]/signed-url/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+
+const SIGNED_URL_EXPIRY = 3600; // 1 hour
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  const label = searchParams.get("label");
+
+  // Fetch video (RLS ensures ownership)
+  const { data: video, error: fetchError } = await supabase
+    .from("videos")
+    .select("id, storage_path")
+    .eq("id", id)
+    .single();
+
+  if (fetchError || !video) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { data: signedUrlData, error: signError } = await supabase.storage
+    .from("videos")
+    .createSignedUrl(video.storage_path, SIGNED_URL_EXPIRY);
+
+  if (signError || !signedUrlData?.signedUrl) {
+    return NextResponse.json(
+      { error: `Failed to create signed URL: ${signError?.message || "unknown"}` },
+      { status: 500 }
+    );
+  }
+
+  // If a label is provided, find the first chunk from this video that
+  // mentions it and return its start_time for seek-to-timestamp.
+  let startTime: number | null = null;
+  if (label) {
+    const { data: chunk } = await supabase
+      .from("chunks")
+      .select("start_time")
+      .eq("video_id", id)
+      .ilike("content", `%${label}%`)
+      .order("start_time", { ascending: true })
+      .limit(1)
+      .single();
+
+    if (chunk?.start_time != null) {
+      startTime = chunk.start_time;
+    }
+  }
+
+  return NextResponse.json({
+    url: signedUrlData.signedUrl,
+    expiresIn: SIGNED_URL_EXPIRY,
+    startTime,
+  });
+}

--- a/components/graph/graph-explorer.tsx
+++ b/components/graph/graph-explorer.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { VideoPlayer } from "@/components/video/video-player";
 
 interface GraphNode {
   id: string;
@@ -37,6 +38,7 @@ interface SelectedNode {
   type: string;
   label: string;
   properties: Record<string, unknown>;
+  source_video_id: string | null;
   source_video_title: string | null;
   edges: { relationship: string; target: string; direction: "out" | "in" }[];
 }
@@ -50,6 +52,7 @@ export function GraphExplorer() {
   const [selectedInstructors, setSelectedInstructors] = useState<Set<string>>(new Set());
   const [selectedInstructionals, setSelectedInstructionals] = useState<Set<string>>(new Set());
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+  const [playingVideo, setPlayingVideo] = useState<{ id: string; title: string; label: string } | null>(null);
   const cyRef = useRef<cytoscape.Core | null>(null);
 
   const fetchGraph = useCallback(async () => {
@@ -258,6 +261,7 @@ export function GraphExplorer() {
       type: node.type,
       label: node.label,
       properties: node.properties,
+      source_video_id: node.source_video_id || null,
       source_video_title: node.source_video_title || null,
       edges: nodeEdges,
     });
@@ -311,7 +315,22 @@ export function GraphExplorer() {
                   <p className="text-xs font-medium text-muted-foreground mb-1">
                     Source
                   </p>
-                  <p className="text-xs">{selectedNode.source_video_title}</p>
+                  {selectedNode.source_video_id ? (
+                    <button
+                      className="text-xs text-primary hover:underline text-left"
+                      onClick={() =>
+                        setPlayingVideo({
+                          id: selectedNode.source_video_id!,
+                          title: selectedNode.source_video_title!,
+                          label: selectedNode.label,
+                        })
+                      }
+                    >
+                      {selectedNode.source_video_title}
+                    </button>
+                  ) : (
+                    <p className="text-xs">{selectedNode.source_video_title}</p>
+                  )}
                 </div>
               )}
               {Object.keys(selectedNode.properties).length > 0 && (
@@ -368,6 +387,15 @@ export function GraphExplorer() {
           }}
         />
       </div>
+
+      {playingVideo && (
+        <VideoPlayer
+          videoId={playingVideo.id}
+          title={playingVideo.title}
+          searchLabel={playingVideo.label}
+          onClose={() => setPlayingVideo(null)}
+        />
+      )}
     </div>
   );
 }

--- a/components/video/video-player.tsx
+++ b/components/video/video-player.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface VideoPlayerProps {
+  videoId: string;
+  title: string;
+  /** Node label to search for in chunks — used to find the timestamp */
+  searchLabel?: string;
+  onClose: () => void;
+}
+
+export function VideoPlayer({
+  videoId,
+  title,
+  searchLabel,
+  onClose,
+}: VideoPlayerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [url, setUrl] = useState<string | null>(null);
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSignedUrl() {
+      const params = new URLSearchParams();
+      if (searchLabel) params.set("label", searchLabel);
+      const qs = params.toString();
+      const response = await fetch(
+        `/api/videos/${videoId}/signed-url${qs ? `?${qs}` : ""}`
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || "Failed to load video.");
+        setLoading(false);
+        return;
+      }
+      const data = await response.json();
+      setUrl(data.url);
+      if (data.startTime != null) {
+        setStartTime(data.startTime);
+      }
+      setLoading(false);
+    }
+    fetchSignedUrl();
+  }, [videoId, searchLabel]);
+
+  useEffect(() => {
+    if (url && videoRef.current && startTime != null) {
+      videoRef.current.currentTime = startTime;
+    }
+  }, [url, startTime]);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="relative w-full max-w-4xl mx-4">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm text-white font-medium truncate pr-4">
+            {title}
+            {startTime ? ` — ${formatTime(startTime)}` : ""}
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-white hover:text-white/80 h-7 px-2"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+        </div>
+        <div className="bg-black rounded-lg overflow-hidden">
+          {loading && (
+            <div className="flex items-center justify-center h-64">
+              <p className="text-sm text-white/60">Loading video...</p>
+            </div>
+          )}
+          {error && (
+            <div className="flex items-center justify-center h-64">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+          {url && (
+            <video
+              ref={videoRef}
+              src={url}
+              controls
+              className="w-full"
+              controlsList="nodownload"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- Added `GET /api/videos/{id}/signed-url` endpoint that generates a 1-hour signed URL for Supabase Storage video playback
- Created `VideoPlayer` modal component with HTML5 `<video>` element, Escape/backdrop close, download disabled
- Made source video references clickable in the graph node detail panel — clicking opens the player
- Seek-to-timestamp: the endpoint accepts `?label=` to search chunks for the first mention of the node's label and returns `start_time`

Closes #54

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: select a node with a source video, click the source link — confirm player opens
- [ ] Manual: verify video plays and seeks to the timestamp where the technique is discussed
- [ ] Manual: press Escape or click backdrop — confirm player closes
- [ ] Manual: verify unauthenticated requests to signed-url return 401

Generated with Claude Code
