### PR TITLE
feat(graph): show explanatory message when no segments found for a node

### DIFF
--- a/components/graph/graph-explorer.tsx
+++ b/components/graph/graph-explorer.tsx
@@ -409,6 +409,14 @@ export function GraphExplorer() {
                   <p className="text-xs text-muted-foreground">Loading segments...</p>
                 </div>
               )}
+              {!segmentsLoading && segments.length === 0 && (
+                <div className="mb-3">
+                  <p className="text-xs text-muted-foreground italic">
+                    This concept was identified in the knowledge graph but
+                    couldn&apos;t be linked to a specific video timestamp.
+                  </p>
+                </div>
+              )}
               {Object.keys(selectedNode.properties).length > 0 && (
                 <div className="mb-3">
                   <p className="text-xs font-medium text-muted-foreground mb-1">


### PR DESCRIPTION
## Summary
- When no related video segments are found for a selected graph node, the detail panel now shows an explanatory message instead of silently hiding the section
- Message: "This concept was identified in the knowledge graph but couldn't be linked to a specific video timestamp."
- Styled as italic muted text — informative without being alarming
- Not shown during loading, only after fetch completes with zero results

Closes #99

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: click a concept node with no segment matches — confirm explanatory message appears
- [ ] Manual: click a technique node with segment matches — confirm "Related Segments" list shows (no message)
- [ ] Manual: confirm message is not visible during loading state

Generated with Claude Code
