### PR TITLE
fix(auth): clean up onAuthStateChange listener to prevent stale redirects

### DIFF
--- a/app/(auth)/auth/callback/page.tsx
+++ b/app/(auth)/auth/callback/page.tsx
@@ -12,7 +12,10 @@ export default function AuthCallbackPage() {
 
     // Supabase JS client automatically detects the hash fragment
     // from the magic link and exchanges it for a session.
-    supabase.auth.onAuthStateChange((event) => {
+    // IMPORTANT: must unsubscribe on unmount — with the singleton client,
+    // a stale listener persists and fires router.push("/") on every
+    // token refresh, causing unexpected dashboard redirects.
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
       if (event === "SIGNED_IN") {
         router.push("/");
         router.refresh();
@@ -28,6 +31,10 @@ export default function AuthCallbackPage() {
         router.push(`/login?error=${encodeURIComponent(error)}`);
       }
     }
+
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [router]);
 
   return (


### PR DESCRIPTION
## Summary
- Added useEffect cleanup that calls `subscription.unsubscribe()` when the auth callback page unmounts
- Root cause: the singleton Supabase client kept the `onAuthStateChange` listener alive after navigating away from `/auth/callback`. Every token refresh fired `SIGNED_IN`, which triggered the stale `router.push("/")`, redirecting to the dashboard
- This is the actual root cause of the "bounce to dashboard" bug that persisted through #75 (getSession fallback), #91 (middleware exclusion), and the singleton/no-op lock fixes

Closes #103

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: log in via magic link — confirm redirect to dashboard works
- [ ] Manual: navigate to /videos, stay for several minutes — confirm no dashboard redirect
- [ ] Manual: start a long upload — confirm page stays on /videos throughout

Generated with Claude Code
