### PR TITLE
feat(graph): three-column layout with node detail panel on the right

### DIFF
--- a/components/graph/graph-explorer.tsx
+++ b/components/graph/graph-explorer.tsx
@@ -344,9 +344,33 @@ export function GraphExplorer() {
           selectedInstructionals={selectedInstructionals}
           onToggleInstructional={handleToggleInstructional}
         />
+      </div>
 
-        {selectedNode && (
-          <Card className="mt-4">
+      {/* Graph canvas */}
+      <div className="flex-1 border rounded-lg overflow-hidden bg-white">
+        <CytoscapeComponent
+          elements={elements}
+          stylesheet={cytoscapeStylesheet}
+          layout={{ name: layout }}
+          style={{ width: "100%", height: "100%" }}
+          cy={(cy: cytoscape.Core) => {
+            cyRef.current = cy;
+            cy.on("tap", "node", (evt: EventObject) => {
+              handleNodeSelect(evt.target.id());
+            });
+            cy.on("tap", (evt: EventObject) => {
+              if (evt.target === cy) {
+                setSelectedNode(null);
+              }
+            });
+          }}
+        />
+      </div>
+
+      {/* Node detail panel — right column */}
+      {selectedNode && (
+        <div className="w-64 shrink-0 overflow-y-auto">
+          <Card>
             <CardHeader className="pb-2">
               <CardDescription>{selectedNode.type}</CardDescription>
               <CardTitle className="text-base">{selectedNode.label}</CardTitle>
@@ -448,29 +472,8 @@ export function GraphExplorer() {
               )}
             </CardContent>
           </Card>
-        )}
-      </div>
-
-      {/* Graph canvas */}
-      <div className="flex-1 border rounded-lg overflow-hidden bg-white">
-        <CytoscapeComponent
-          elements={elements}
-          stylesheet={cytoscapeStylesheet}
-          layout={{ name: layout }}
-          style={{ width: "100%", height: "100%" }}
-          cy={(cy: cytoscape.Core) => {
-            cyRef.current = cy;
-            cy.on("tap", "node", (evt: EventObject) => {
-              handleNodeSelect(evt.target.id());
-            });
-            cy.on("tap", (evt: EventObject) => {
-              if (evt.target === cy) {
-                setSelectedNode(null);
-              }
-            });
-          }}
-        />
-      </div>
+        </div>
+      )}
 
       {playingVideo && (
         <VideoPlayer


### PR DESCRIPTION
## Summary
- Moved node detail panel from below controls in the left sidebar to its own right-side column
- Layout: controls (left, w-56) | graph canvas (center, flex-1) | detail (right, w-64)
- Right column only appears when a node is selected — no empty column when nothing selected
- Controls sidebar remains fully visible and scrollable regardless of node selection
- Graph canvas resizes smoothly when the right panel appears/disappears

Closes #107

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: click a node — confirm detail panel appears on the right side
- [ ] Manual: click graph background — confirm right panel disappears, canvas expands
- [ ] Manual: confirm controls sidebar remains fully visible with a node selected

Generated with Claude Code
