### PR TITLE
fix(videos): keep ingest button disabled until status changes

### DIFF
--- a/components/videos/video-list.tsx
+++ b/components/videos/video-list.tsx
@@ -151,9 +151,13 @@ export function VideoList({ videos, onDelete, onRefresh }: VideoListProps) {
     if (!response.ok) {
       const data = await response.json();
       alert(data.error || "Failed to start ingestion.");
+      setIngesting(null);
+      return;
     }
 
-    setIngesting(null);
+    // Don't clear ingesting — keep the button disabled until the next
+    // poll/refresh updates the video status to "transcribing", at which
+    // point canIngest becomes false and the button hides entirely.
     onRefresh();
   }
 


### PR DESCRIPTION
## Summary
- Ingest button now stays disabled after successful API response until the next poll updates the video status
- Previously, `setIngesting(null)` ran immediately after the 202 response, re-enabling the button before the status changed to "transcribing"
- On error, the button re-enables so the user can retry
- The `canIngest` check (`status === "uploaded" || "error"`) naturally hides the button once the poll picks up "transcribing"

Closes #105

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: click Ingest — confirm button stays disabled, no flash of re-enabled state
- [ ] Manual: confirm "Transcribing" status appears within 5 seconds (next poll)
- [ ] Manual: if ingestion fails, confirm button re-enables for retry

Generated with Claude Code
