### PR TITLE
fix(videos): replace loading text with skeleton card placeholders

### DIFF
--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -73,7 +73,17 @@ export default function VideosPage() {
       <Separator className="my-6" />
 
       {loading ? (
-        <p className="text-sm text-muted-foreground">Loading videos...</p>
+        <div className="flex flex-col gap-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="rounded-lg border bg-card p-4 animate-pulse">
+              <div className="flex items-center justify-between mb-2">
+                <div className="h-5 w-48 bg-muted rounded" />
+                <div className="h-5 w-20 bg-muted rounded" />
+              </div>
+              <div className="h-4 w-64 bg-muted rounded" />
+            </div>
+          ))}
+        </div>
       ) : (
         <VideoList videos={videos} onDelete={fetchVideos} onRefresh={fetchVideos} />
       )}


### PR DESCRIPTION
## Summary
- Replaced "Loading videos..." text with 3 pulsing skeleton card placeholders
- Skeleton matches the video card layout: title bar (h-5 w-48) + status badge area (h-5 w-20) + filename row (h-4 w-64)
- Uses Tailwind `animate-pulse` on `bg-muted` divs — no new dependencies
- Improves perceived performance by giving the page visual structure immediately

Closes #109

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: navigate to /videos — confirm skeleton cards appear immediately, then data fills in
- [ ] Manual: confirm skeleton card dimensions roughly match actual video cards

Generated with Claude Code
