### PR TITLE
feat(ingestion): extract knowledge per-instructional with cross-segment context

### DIFF
--- a/app/api/ingest/[videoId]/route.ts
+++ b/app/api/ingest/[videoId]/route.ts
@@ -177,7 +177,10 @@ async function runPipeline(
       `Embedding complete for video ${videoId}: ${embeddedChunks.length} chunks stored`
     );
 
-    // ── Step 3: Knowledge Extraction ────────────────────────────────
+    // ── Step 3: Knowledge Extraction (per-instructional) ─────────────
+    // Gather all transcriptions for the same instructional to give
+    // the LLM full cross-segment context. This produces better
+    // relationships and fewer duplicate nodes than per-video extraction.
     const { data: ontologyEntries } = await supabase
       .from("ontology_entries")
       .select("*");
@@ -186,14 +189,48 @@ async function runPipeline(
       throw new Error("No ontology entries found — run seed.sql first");
     }
 
-    const extraction = await extractKnowledge(result.text, ontologyEntries, metadata);
+    // Find all videos in the same instructional
+    let siblingVideoIds = [videoId];
+    let combinedText = result.text;
+
+    if (metadata?.instructor && metadata?.instructional) {
+      const { data: siblings } = await supabase
+        .from("videos")
+        .select("id, title, transcriptions(text)")
+        .eq("user_id", userId)
+        .eq("instructor", metadata.instructor)
+        .eq("instructional", metadata.instructional)
+        .order("title", { ascending: true });
+
+      if (siblings && siblings.length > 1) {
+        siblingVideoIds = siblings.map((s) => s.id);
+        combinedText = siblings
+          .map((s) => {
+            const tx = Array.isArray(s.transcriptions)
+              ? s.transcriptions[0]
+              : (s.transcriptions as { text: string } | null);
+            return tx?.text
+              ? `[Segment: ${s.title}]\n${tx.text}`
+              : null;
+          })
+          .filter(Boolean)
+          .join("\n\n---\n\n");
+
+        console.log(
+          `Combined ${siblings.length} segments for "${metadata.instructor} / ${metadata.instructional}" (${combinedText.length} chars)`
+        );
+      }
+    }
+
+    const extraction = await extractKnowledge(combinedText, ontologyEntries, metadata);
     console.log(
-      `Extracted ${extraction.nodes.length} nodes, ${extraction.edges.length} edges for video ${videoId}`
+      `Extracted ${extraction.nodes.length} nodes, ${extraction.edges.length} edges for instructional`
     );
 
-    const stats = await storeExtraction(supabase, userId, videoId, extraction);
+    // Clear previous extraction for ALL sibling videos, then store new
+    const stats = await storeExtraction(supabase, userId, videoId, extraction, siblingVideoIds);
     console.log(
-      `Stored extraction for video ${videoId}: ${stats.nodesCreated} new nodes, ` +
+      `Stored extraction: ${stats.nodesCreated} new nodes, ` +
         `${stats.edgesCreated} edges, ${stats.totalNodes} total nodes`
     );
 

--- a/lib/extraction.ts
+++ b/lib/extraction.ts
@@ -107,11 +107,15 @@ export async function storeExtraction(
   supabase: Awaited<ReturnType<typeof import("@/lib/supabase/server").createServerClient>>,
   userId: string,
   videoId: string,
-  extraction: ExtractionResult
+  extraction: ExtractionResult,
+  cleanupVideoIds?: string[]
 ) {
-  // Delete previous extraction for this video (idempotent re-run)
-  await supabase.from("edges").delete().eq("source_video_id", videoId);
-  await supabase.from("nodes").delete().eq("source_video_id", videoId);
+  // Delete previous extraction for all sibling videos (per-instructional re-run)
+  const idsToClean = cleanupVideoIds || [videoId];
+  for (const id of idsToClean) {
+    await supabase.from("edges").delete().eq("source_video_id", id);
+    await supabase.from("nodes").delete().eq("source_video_id", id);
+  }
 
   // Build a map of label → node ID (including existing nodes for this user)
   const nodeIdMap = new Map<string, string>();


### PR DESCRIPTION
## Summary

The extraction step now gathers all transcriptions for the same instructor + instructional before calling the LLM, giving it full cross-segment context.

**Before:** Each video segment extracted independently → 10 separate LLM calls for 10 segments, each seeing only 3-5 minutes of content. Missed cross-segment relationships, produced duplicate nodes.

**After:** All segments for the same instructional are concatenated with `[Segment: title]` markers → 1 LLM call with full context. Cross-segment relationships captured, fewer duplicates.

### Changes
- Ingest route queries sibling videos by `instructor` + `instructional` after transcription
- Concatenates all sibling transcriptions with segment markers
- `storeExtraction` accepts an array of cleanup video IDs to clear all siblings' previous nodes/edges
- Single-video instructionals (no siblings) work exactly as before

Closes #121

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: upload 3 segments of the same instructional, ingest the last one — confirm extraction covers all 3
- [ ] Manual: upload a single-video instructional — confirm it extracts normally (no regression)
- [ ] Manual: compare graph quality between per-video and per-instructional extraction

Generated with Claude Code
