### PR TITLE
fix(graph): make graph page responsive for mobile viewports

### DIFF
--- a/components/graph/graph-explorer.tsx
+++ b/components/graph/graph-explorer.tsx
@@ -63,6 +63,7 @@ export function GraphExplorer() {
   const [selectedInstructionals, setSelectedInstructionals] = useState<Set<string>>(new Set());
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [segments, setSegments] = useState<Segment[]>([]);
+  const [showMobileControls, setShowMobileControls] = useState(false);
   const [segmentsLoading, setSegmentsLoading] = useState(false);
   const [playingVideo, setPlayingVideo] = useState<{ id: string; title: string; label: string; startTime?: number } | null>(null);
   const cyRef = useRef<cytoscape.Core | null>(null);
@@ -325,9 +326,17 @@ export function GraphExplorer() {
   }
 
   return (
-    <div className="flex gap-4 h-[calc(100vh-10rem)]">
-      {/* Sidebar */}
-      <div className="w-56 shrink-0 overflow-y-auto">
+    <div className="flex gap-4 h-[calc(100vh-10rem)] relative">
+      {/* Mobile controls toggle */}
+      <button
+        className="md:hidden absolute top-2 left-2 z-10 bg-card border rounded-lg px-3 py-1.5 text-xs font-medium shadow-sm"
+        onClick={() => setShowMobileControls(!showMobileControls)}
+      >
+        {showMobileControls ? "Hide filters" : "Filters"}
+      </button>
+
+      {/* Sidebar — hidden on mobile, shown via toggle */}
+      <div className={`${showMobileControls ? "absolute z-20 top-10 left-2 bg-card border rounded-lg shadow-lg max-h-[70vh]" : "hidden"} md:block w-56 shrink-0 overflow-y-auto`}>
         <GraphControls
           nodeTypes={nodeTypes}
           visibleTypes={visibleTypes}
@@ -367,9 +376,9 @@ export function GraphExplorer() {
         />
       </div>
 
-      {/* Node detail panel — right column */}
+      {/* Node detail panel — right column on desktop, bottom overlay on mobile */}
       {selectedNode && (
-        <div className="w-64 shrink-0 overflow-y-auto">
+        <div className="fixed bottom-0 left-0 right-0 z-20 max-h-[50vh] md:static md:max-h-none md:z-auto w-full md:w-64 shrink-0 overflow-y-auto bg-background md:bg-transparent border-t md:border-t-0 shadow-lg md:shadow-none">
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>{selectedNode.type}</CardDescription>


### PR DESCRIPTION
## Summary

Makes the graph page responsive for mobile viewports (< 768px):

- **Controls sidebar**: hidden by default on mobile, toggled via a "Filters" button that floats over the graph canvas. Opens as an overlay panel.
- **Node detail panel**: renders as a bottom sheet overlay (max 50vh) on mobile instead of a right column.
- **Graph canvas**: fills the full viewport on mobile, always visible.
- **Desktop layout**: unchanged (three-column: controls | canvas | detail).

Uses only Tailwind responsive utilities (`md:` breakpoint) — no new dependencies.

Closes #106

## Test plan
- [x] npm run lint — zero errors
- [x] npm run typecheck — zero errors
- [x] npm test — 17/17 tests pass
- [ ] Manual: open graph page at 375px width — confirm graph is visible and fills viewport
- [ ] Manual: tap "Filters" button — confirm controls overlay appears
- [ ] Manual: tap a node — confirm detail panel appears as bottom sheet
- [ ] Manual: desktop — confirm layout is unchanged

Generated with Claude Code
